### PR TITLE
Add colors to buttons / Align icon

### DIFF
--- a/ui/components/Button/Button.tsx
+++ b/ui/components/Button/Button.tsx
@@ -71,7 +71,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
               <Loading size={size} variant={variant === 'filled' ? `white` : `primary`} />
             </span>
           )}
-          <span className={`${submitting ? 'opacity-0' : 'opacity-100'} inline-flex ${buttonFamilyClasses['iconPosition'][iconPosition]}`}>
+          <span className={`${submitting ? 'opacity-0' : 'opacity-100'} flex items-center ${buttonFamilyClasses['iconPosition'][iconPosition]}`}>
             {icon && <span>{icon}</span>}
             {children && <span>{children}</span>}
           </span>


### PR DESCRIPTION
The button was not well aligned when there was an icon. This was because we were using `inline-flex` instead of `flex`. An inline element always has some 'weird' padding/margin underneath. I also added a class to align the items center so the icon is in the middle of the text.

I've added a new attribute to define the color.

It was very nice to work in this component. Keep up the good work!