### PR TITLE
Remove padding from Toggle and use fles to align item in the center

### DIFF
--- a/ui/components/Toggle/Toggle.tsx
+++ b/ui/components/Toggle/Toggle.tsx
@@ -13,15 +13,15 @@ interface IToggleFamilyClasses {
 
 const toggleFamilyClasses: IToggleFamilyClasses = {
   size: {
-    md: 'pl-2.5 h-9 w-9',
-    lg: 'pl-4 h-12 w-12'
+    md: 'h-9 w-9',
+    lg: 'h-12 w-12'
   }
 }
 
 const Toggle = ({ size = 'md', disabled }: ToggleProps) => {
   return (
     <RadixToggle.Root
-      className={`bg-primary-white text-primary-base pl-2.5 h-9 w-9 rounded flex items-center text-base shadow hover:bg-primary-200 data-[state=on]:bg-primary-100 data-[state=on]:text-primary-400 focus:shadow-xl disabled:bg-neutral-100 disabled:text-neutral-300 ${toggleFamilyClasses['size'][size]}`}
+      className={`bg-primary-white text-primary-base rounded text-base flex justify-center items-center shadow hover:bg-primary-200 data-[state=on]:bg-primary-100 data-[state=on]:text-primary-400 focus:shadow-xl disabled:bg-neutral-100 disabled:text-neutral-300 ${toggleFamilyClasses['size'][size]}`}
       aria-label="Toggle italic"
       disabled={disabled}
     >


### PR DESCRIPTION
I saw that on the LG button the alignment was of, i purpose to use justify-center to align the content of the toggle in the middle.